### PR TITLE
Panda Universal Forwarding

### DIFF
--- a/panda/board/main.c
+++ b/panda/board/main.c
@@ -70,6 +70,8 @@ void debug_ring_callback(uart_ring *ring) {
 
 // ***************************** USB port *****************************
 
+int usb_live = 0;
+
 int get_health_pkt(void *dat) {
   struct __attribute__((packed)) {
     uint32_t voltage;
@@ -129,6 +131,7 @@ int get_health_pkt(void *dat) {
 }
 
 int usb_cb_ep1_in(uint8_t *usbdata, int len, int hardwired) {
+  usb_live = 1;
   CAN_FIFOMailBox_TypeDef *reply = (CAN_FIFOMailBox_TypeDef *)usbdata;
   int ilen = 0;
   while (ilen < min(len/0x10, 4) && can_pop(&can_rx_q, &reply[ilen])) ilen++;
@@ -137,6 +140,7 @@ int usb_cb_ep1_in(uint8_t *usbdata, int len, int hardwired) {
 
 // send on serial, first byte to select the ring
 void usb_cb_ep2_out(uint8_t *usbdata, int len, int hardwired) {
+  usb_live = 1;  
   if (len == 0) return;
   uart_ring *ur = get_ring_by_number(usbdata[0]);
   if (!ur) return;
@@ -147,6 +151,7 @@ void usb_cb_ep2_out(uint8_t *usbdata, int len, int hardwired) {
 
 // send on CAN
 void usb_cb_ep3_out(uint8_t *usbdata, int len, int hardwired) {
+  usb_live = 1;  
   int dpkt = 0;
   for (dpkt = 0; dpkt < len; dpkt += 0x10) {
     uint32_t *tf = (uint32_t*)(&usbdata[dpkt]);
@@ -166,11 +171,13 @@ void usb_cb_ep3_out(uint8_t *usbdata, int len, int hardwired) {
 int is_enumerated = 0;
 
 void usb_cb_enumeration_complete() {
+  usb_live = 1;
   puts("USB enumeration complete\n");
   is_enumerated = 1;
 }
 
 int usb_cb_control_msg(USB_Setup_TypeDef *setup, uint8_t *resp, int hardwired) {
+  usb_live = 1;
   int resp_len = 0;
   uart_ring *ur = NULL;
   int i;
@@ -652,7 +659,28 @@ int main() {
     #endif
 
     // reset this every 16th pass
-    if ((cnt&0xF) == 0) pending_can_live = 0;
+    if ((cnt&0xF) == 0) {
+      // // check if usb connection is active, attempt forwarding if not
+      // if (usb_live == 0 && current_safety_mode != SAFETY_FORWARD) {
+      //   safety_set_mode(SAFETY_FORWARD, 0);
+      //   can_silent = ALL_CAN_LIVE;
+      //   can_init_all();
+      // }
+      // usb_live = 0;
+      pending_can_live = 0;
+    }
+
+    // reset this every 2nd pass
+    if ((cnt&0x2) == 0) {
+      // check if usb connection is active, attempt forwarding if not
+      if (usb_live == 0 && current_safety_mode != SAFETY_FORWARD) {
+        safety_set_mode(SAFETY_FORWARD, 0);
+        can_silent = ALL_CAN_LIVE;
+        can_init_all();
+      }
+      usb_live = 0;
+      // pending_can_live = 0;
+    }    
 
     #ifdef DEBUG
       puts("** blink ");

--- a/panda/board/main.c
+++ b/panda/board/main.c
@@ -491,6 +491,18 @@ int spi_cb_rx(uint8_t *data, int len, uint8_t *data_out) { return 0; };
 
 #endif
 
+// allow safety_forward to enable sending can messages
+void safety_cb_enable_all() {
+      // allow sending can messages
+      can_silent = ALL_CAN_LIVE;
+      can_autobaud_enabled[0] = false;
+      can_autobaud_enabled[1] = false;
+      #ifdef PANDA
+        can_autobaud_enabled[2] = false;
+      #endif
+      can_init_all();
+}
+
 
 // ***************************** main code *****************************
 
@@ -659,27 +671,17 @@ int main() {
     #endif
 
     // reset this every 16th pass
-    if ((cnt&0xF) == 0) {
-      // // check if usb connection is active, attempt forwarding if not
-      // if (usb_live == 0 && current_safety_mode != SAFETY_FORWARD) {
-      //   safety_set_mode(SAFETY_FORWARD, 0);
-      //   can_silent = ALL_CAN_LIVE;
-      //   can_init_all();
-      // }
-      // usb_live = 0;
-      pending_can_live = 0;
-    }
+    if ((cnt&0xF) == 0) pending_can_live = 0;
 
     // reset this every 2nd pass
     if ((cnt&0x2) == 0) {
       // check if usb connection is active, attempt forwarding if not
       if (usb_live == 0 && current_safety_mode != SAFETY_FORWARD) {
         safety_set_mode(SAFETY_FORWARD, 0);
-        can_silent = ALL_CAN_LIVE;
+        // leave can_silent in it's current state.  Fingerprinting will work with ALL_CAN_SILENT
         can_init_all();
       }
       usb_live = 0;
-      // pending_can_live = 0;
     }    
 
     #ifdef DEBUG

--- a/panda/board/safety.h
+++ b/panda/board/safety.h
@@ -62,6 +62,7 @@ int controls_allowed = 0;
 #include "safety/safety_cadillac.h"
 #include "safety/safety_hyundai.h"
 #include "safety/safety_elm327.h"
+#include "safety/safety_forward.h"
 
 const safety_hooks *current_hooks = &nooutput_hooks;
 
@@ -104,6 +105,7 @@ typedef struct {
 #define SAFETY_TOYOTA_NOLIMITS 0x1336
 #define SAFETY_ALLOUTPUT 0x1337
 #define SAFETY_ELM327 0xE327
+#define SAFETY_FORWARD 0xFA0D
 
 const safety_hook_config safety_hook_registry[] = {
   {SAFETY_NOOUTPUT, &nooutput_hooks},
@@ -120,15 +122,19 @@ const safety_hook_config safety_hook_registry[] = {
 #endif
   {SAFETY_ALLOUTPUT, &alloutput_hooks},
   {SAFETY_ELM327, &elm327_hooks},
+  {SAFETY_FORWARD, &forward_hooks},
 };
 
 #define HOOK_CONFIG_COUNT (sizeof(safety_hook_registry)/sizeof(safety_hook_config))
+
+extern uint16_t current_safety_mode = SAFETY_NOOUTPUT;
 
 int safety_set_mode(uint16_t mode, int16_t param) {
   for (int i = 0; i < HOOK_CONFIG_COUNT; i++) {
     if (safety_hook_registry[i].id == mode) {
       current_hooks = safety_hook_registry[i].hooks;
       if (current_hooks->init) current_hooks->init(param);
+      current_safety_mode = mode;
       return 0;
     }
   }

--- a/panda/board/safety.h
+++ b/panda/board/safety.h
@@ -50,6 +50,8 @@ typedef struct {
 // This can be set by the safety hooks.
 int controls_allowed = 0;
 
+void safety_cb_enable_all();
+
 // Include the actual safety policies.
 #include "safety/safety_defaults.h"
 #include "safety/safety_honda.h"

--- a/panda/board/safety/safety_forward.h
+++ b/panda/board/safety/safety_forward.h
@@ -64,7 +64,9 @@ static void forward_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       }
     }
     if (matched) {
-      // we found an exact match, begin forwarding
+      // re-init can to allow sending messages
+      safety_cb_enable_all();
+      // we found an exact match, begin forwarding with that profile
       identified_car = i;
       break;
     }

--- a/panda/board/safety/safety_forward.h
+++ b/panda/board/safety/safety_forward.h
@@ -1,0 +1,103 @@
+// Candidate Car Fingerprints
+//  fingerprint format:  [[bus#, addr, len], ...]
+//  all fingerprints must be matched before forwarding will occur.
+//  do not use addresses above 2047 if you want it to ever match.
+uint16_t candidate_fp[2][20][3] = { 
+  // Hyundai new Giraffe (camera = bus2)
+  { {2,832,8},{2,1342,6}, {0,339,8},{0,356,4},{0,593,8},{0,608,8},{0,809,8},{0,897,8},{0,902,8},{0,916,8},{0,1056,8},{0,1057,8},{0,1078,4},{0,1170,8},{0,1265,4},{0,1312,8},{0,1345,8},{0,1419,8} },
+  // Hyundai old Giraffe (camera = bus1)
+  { {1,832,8},{1,1342,6}, {0,339,8},{0,356,4},{0,593,8},{0,608,8},{0,809,8},{0,897,8},{0,902,8},{0,916,8},{0,1056,8},{0,1057,8},{0,1078,4},{0,1170,8},{0,1265,4},{0,1312,8},{0,1345,8},{0,1419,8} }
+};
+
+// Candidate Car Forwarding Profiles
+//  forwarding format:   [bus0to, bus1to, bus2to]
+//    array[bus#] = bus# to forward message to (or -1 for no forwarding)
+//  the order of the forwarding profiles must match the candidate_fp order above.
+int forward_profile[2][3] = { 
+  // Hyundai new Giraffe (camera = bus2)
+  {  2, -1,  0 },
+  // Hyundai old Giraffe (camera = bus1)
+  {  1,  0, -1 }
+};
+
+// Stores the array index of a matched car fingerprint/forwarding profile
+int identified_car = -1;
+
+
+static void forward_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
+
+  // skip everything if we've already completed fingerprinting 
+  //   can be extended in the future for fancier forwarding rules based on specific car id
+  if (identified_car >= 0) {
+    return;
+  }
+
+  // temporarily store our bus number, address, and data length
+  uint16_t msg_metadata[3];
+
+  // store the bus number
+  msg_metadata[0] = (uint32_t)0x000000FF & (to_push->RDTR >> 4);
+  // get the can message info needed for fingerprinting
+  if (to_push->RIR & 4) {
+    // Extended addresses
+    // Not looked at, but have to be separated to avoid address collision
+    return;
+  } else {
+    // store the normal address
+    msg_metadata[1] = (uint32_t)0x000007FF & (to_push->RIR >> 21);
+  }
+  // store the length
+  msg_metadata[2] = (uint32_t)0x0000000F & (to_push->RDTR);
+
+  // iterate over all candidate fingerprints
+  for (int i = 0; i < (sizeof(candidate_fp) / sizeof(candidate_fp[0])); i++) {
+    bool matched = true;
+    // iterate over all fingers in this fingerprint
+    for (int j = 0; j < (sizeof(candidate_fp[i]) / sizeof(candidate_fp[i][0])); j++) {
+      // search for a match
+      if ( memcmp(candidate_fp[i][j], msg_metadata, sizeof(uint16_t)*3) == 0) {
+        // we matched the candidate finger, so "remove" it's address from the fingerprint array
+        candidate_fp[i][j][1] = (uint16_t) 0;
+      // if any array addr isn't zero in this fingerprint, then we haven't completely matched this car
+      } else if (candidate_fp[i][j][1] != (uint16_t) 0) {
+        matched = false;
+      }
+    }
+    if (matched) {
+      // we found an exact match, begin forwarding
+      identified_car = i;
+      break;
+    }
+  }
+}
+
+static int forward_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
+  if (identified_car >= 0) {
+      // must be true for fwd_hook to function
+      return true;
+  }
+  return false;
+}
+
+static int forward_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
+  // can be extended in the future for fancier forwarding based on specific id
+  if (identified_car >= 0) {
+      // Hopefully you put valid bus numbers in the forwarding profiles!
+      return forward_profile[identified_car][bus_num];
+  }
+  return -1;
+}
+
+static void forward_init(int16_t param) {
+  controls_allowed = 0;
+}
+
+const safety_hooks forward_hooks = {
+  .init = forward_init,
+  .rx = forward_rx_hook,
+  .tx = forward_tx_hook,
+  .tx_lin = nooutput_tx_lin_hook,
+  .ignition = default_ign_hook,
+  .fwd = forward_fwd_hook,
+};
+


### PR DESCRIPTION
PUF implements automatic forwarding of car/camera buses based on "universal" vehicle fingerprints.  Initial support is for Hyundai/Kia, but PUF is designed to be easily extended to other manufacturers and for more complicated forwarding if necessary.  

The Hyundai fingerprint included was created by taking the intersection of all of the existing Hyundai fingerprints and then doing a frequency analysis of the remaining packets on the CAN bus for my vehicle.  Only messages with a rate at least 10% of the maximum message rate on bus 0 were included in the final fingerprint.

There's probably a lot of things here that could be done better, but my C-fu is pretty poor so please feel free to criticize, comment, fix or extend as you see fit.  I can say however that it appears to work well.  It properly identifies my Kia with the included fingerprints, and if I change any single value in the fingerprint it does not forward.  Connecting and disconnecting the USB cable works as expected, with the exception that the forwarding is actually predicated upon a lack of USB transfer/control messages and not a disconnection event.  This means that shutting down boardd on the Eon is actually enough to get it to switch over into forwarding mode.  

There's some constant cpu time spent processing fingerprints when the USB connection is not active, but if necessary I suppose that could be easily overcome by time-limiting the fingerprinting process or using some kind of ignition hook.

Switches?  Who needs stinking switches?

