### PR TITLE
Small adjustment for Elantra Tuning

### DIFF
--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -66,8 +66,8 @@ class CarInterface(object):
     centerToFront_civic = wheelbase_civic * 0.4
     centerToRear_civic = wheelbase_civic - centerToFront_civic
     rotationalInertia_civic = 2500
-    tireStiffnessFront_civic = 192150   # Elantra Requires 192150 * 0.405
-    tireStiffnessRear_civic = 202500    # Elantra Requires 202500 * 0.405
+    tireStiffnessFront_civic = 192150
+    tireStiffnessRear_civic = 202500
 
     ret.steerActuatorDelay = 0.1  # Default delay
     tire_stiffness_factor = 1.
@@ -100,8 +100,9 @@ class CarInterface(object):
       ret.mass = 1275 + std_cargo
       ret.wheelbase = 2.7
       ret.steerRatio = 13.73        # Spec
+      tire_stiffness_factor = 0.385
       ret.steerKiBP, ret.steerKpBP = [[0.], [0.]]
-      ret.steerKpV, ret.steerKiV = [[0.40], [0.1]]
+      ret.steerKpV, ret.steerKiV = [[0.25], [0.05]]
       ret.minSteerSpeed = 32 * CV.MPH_TO_MS
     elif candidate == CAR.GENESIS:
       ret.steerKf = 0.00005


### PR DESCRIPTION
 - Put tire-stiffness for Elantra under it's own elif candidate value group.
 - Smaller drop in tire-stiffness demonstrates improvement in slow tight turns.
 - Dialing Kp and Ki down allows for the appearance of smoother steering wheel operations at all speeds.