### PR TITLE
Merge Devel Branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,8 @@ selfdrive/proclogd/proclogd
 selfdrive/ui/ui
 selfdrive/test/tests/plant/out
 /src/
-
+openpilot_tools
 one
-
+selfdrive/visiond/visiond
 .vscode/*.json
 launch_chffrplus.sh
-

--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -242,12 +242,12 @@ class CarState(object):
     self.park_brake = cp.vl["CGW1"]['CF_Gway_ParkBrakeSw']
     self.main_on = True
     if self.has_scc:
-        self.acc_active = (cp.vl["SCC12"]['ACCMode'] != 0) if not self.cstm_btns.get_button_status("alwon") else \
+      self.acc_active = (cp.vl["SCC12"]['ACCMode'] != 0) if not self.cstm_btns.get_button_status("alwon") else \
             (cp.vl["SCC11"]["MainMode_ACC"] != 0)  # I'm Dangerous!
-        self.acc_active_real = (cp.vl["SCC12"]['ACCMode'] !=0)
+      self.acc_active_real = (cp.vl["SCC12"]['ACCMode'] !=0)
     else:
-        self.acc_active = (cp.vl["LVR12"]['CF_Lvr_CruiseSet'] != 0)
-        self.acc_active_real = self.acc_active
+      self.acc_active = (cp.vl["LVR12"]['CF_Lvr_CruiseSet'] != 0)
+      self.acc_active_real = self.acc_active
     self.pcm_acc_status = int(self.acc_active)
 
     # calc best v_ego estimate, by averaging two opposite corners
@@ -326,13 +326,13 @@ class CarState(object):
     # Gear Selecton via TCU12
     gear2 = cp.vl["TCU12"]["CUR_GR"]
     if gear2 == 0:
-        self.gear_tcu = "park"
+      self.gear_tcu = "park"
     elif gear2 == 14:
-        self.gear_tcu = "reverse"
+      self.gear_tcu = "reverse"
     elif gear2 > 0 and gear2 < 14:    # unaware of anything over 8 currently
-        self.gear_tcu = "drive"
+      self.gear_tcu = "drive"
     else:
-        self.gear_tcu = "unknown"
+      self.gear_tcu = "unknown"
 
     # save the entire LKAS11, CLU11 and MDPS12
     if cp_cam.can_valid == True:

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -97,28 +97,28 @@ def create_mdps12(packer, car_fingerprint, cnt, mdps12, lkas11, camcan, checksum
 def learn_checksum(packer, lkas11):
     # Learn checksum used
     values = {
-        "CF_Lkas_Icon": lkas11["CF_Lkas_Icon"],
-        "CF_Lkas_LdwsSysState": lkas11["CF_Lkas_LdwsSysState"],
-        "CF_Lkas_SysWarning": lkas11["CF_Lkas_SysWarning"],
-        "CF_Lkas_LdwsLHWarning": lkas11["CF_Lkas_LdwsLHWarning"],
-        "CF_Lkas_LdwsRHWarning": lkas11["CF_Lkas_LdwsRHWarning"],
-        "CF_Lkas_HbaLamp": lkas11["CF_Lkas_HbaLamp"],
-        "CF_Lkas_FcwBasReq": lkas11["CF_Lkas_FcwBasReq"],
-        "CR_Lkas_StrToqReq": lkas11["CR_Lkas_StrToqReq"],
-        "CF_Lkas_ActToi": lkas11["CF_Lkas_ActToi"],
-        "CF_Lkas_ToiFlt": lkas11["CF_Lkas_ToiFlt"],
-        "CF_Lkas_HbaSysState": lkas11["CF_Lkas_HbaSysState"],
-        "CF_Lkas_FcwOpt": lkas11["CF_Lkas_FcwOpt"],
-        "CF_Lkas_HbaOpt": lkas11["CF_Lkas_HbaOpt"],
-        "CF_Lkas_MsgCount": lkas11["CF_Lkas_MsgCount"],
-        "CF_Lkas_FcwSysState": lkas11["CF_Lkas_FcwSysState"],
-        "CF_Lkas_FcwCollisionWarning": lkas11["CF_Lkas_FcwCollisionWarning"],
-        "CF_Lkas_FusionState": lkas11["CF_Lkas_FusionState"],
-        "CF_Lkas_Chksum": lkas11["CF_Lkas_Chksum"],
-        "CF_Lkas_FcwOpt_USM": lkas11["CF_Lkas_FcwOpt_USM"],
-        "CF_Lkas_LdwsOpt_USM": lkas11["CF_Lkas_LdwsOpt_USM"],
-        "CF_Lkas_Unknown1": lkas11["CF_Lkas_Unknown1"],
-        "CF_Lkas_Unknown2": lkas11["CF_Lkas_Unknown2"],
+      "CF_Lkas_Icon": lkas11["CF_Lkas_Icon"],
+      "CF_Lkas_LdwsSysState": lkas11["CF_Lkas_LdwsSysState"],
+      "CF_Lkas_SysWarning": lkas11["CF_Lkas_SysWarning"],
+      "CF_Lkas_LdwsLHWarning": lkas11["CF_Lkas_LdwsLHWarning"],
+      "CF_Lkas_LdwsRHWarning": lkas11["CF_Lkas_LdwsRHWarning"],
+      "CF_Lkas_HbaLamp": lkas11["CF_Lkas_HbaLamp"],
+      "CF_Lkas_FcwBasReq": lkas11["CF_Lkas_FcwBasReq"],
+      "CR_Lkas_StrToqReq": lkas11["CR_Lkas_StrToqReq"],
+      "CF_Lkas_ActToi": lkas11["CF_Lkas_ActToi"],
+      "CF_Lkas_ToiFlt": lkas11["CF_Lkas_ToiFlt"],
+      "CF_Lkas_HbaSysState": lkas11["CF_Lkas_HbaSysState"],
+      "CF_Lkas_FcwOpt": lkas11["CF_Lkas_FcwOpt"],
+      "CF_Lkas_HbaOpt": lkas11["CF_Lkas_HbaOpt"],
+      "CF_Lkas_MsgCount": lkas11["CF_Lkas_MsgCount"],
+      "CF_Lkas_FcwSysState": lkas11["CF_Lkas_FcwSysState"],
+      "CF_Lkas_FcwCollisionWarning": lkas11["CF_Lkas_FcwCollisionWarning"],
+      "CF_Lkas_FusionState": lkas11["CF_Lkas_FusionState"],
+      "CF_Lkas_Chksum": lkas11["CF_Lkas_Chksum"],
+      "CF_Lkas_FcwOpt_USM": lkas11["CF_Lkas_FcwOpt_USM"],
+      "CF_Lkas_LdwsOpt_USM": lkas11["CF_Lkas_LdwsOpt_USM"],
+      "CF_Lkas_Unknown1": lkas11["CF_Lkas_Unknown1"],
+      "CF_Lkas_Unknown2": lkas11["CF_Lkas_Unknown2"],
     }
 
     dat = packer.make_can_msg("LKAS11", 0, values)[2]
@@ -133,11 +133,11 @@ def learn_checksum(packer, lkas11):
     cs7b = ((sum(dat[:6]) + dat[7]) % 256)
 
     if cs6b != crc and cs7b != crc and cs6b != cs7b:
-        if crc == lkas11["CF_Lkas_Chksum"]:
-            return "crc8"
-        elif cs6b == lkas11["CF_Lkas_Chksum"]:
-            return "6B"
-        elif cs7b == lkas11["CF_Lkas_Chksum"]:
-            return "7B"
+      if crc == lkas11["CF_Lkas_Chksum"]:
+        return "crc8"
+      elif cs6b == lkas11["CF_Lkas_Chksum"]:
+        return "6B"
+      elif cs7b == lkas11["CF_Lkas_Chksum"]:
+        return "7B"
 
     return "NONE"

--- a/selfdrive/car/hyundai/hyundaican.py
+++ b/selfdrive/car/hyundai/hyundaican.py
@@ -14,7 +14,8 @@ def create_lkas11(packer, car_fingerprint, apply_steer, steer_req, cnt, \
   values = {
     "CF_Lkas_Icon": 2 if (car_fingerprint in FEATURES["icon_basic"]) else \
         (lkas11["CF_Lkas_Icon"] if use_stock else (2 if enabled else 0)),
-    "CF_Lkas_LdwsSysState": lkas11["CF_Lkas_LdwsSysState"] if use_stock else 3,
+    "CF_Lkas_LdwsSysState": lkas11["CF_Lkas_LdwsSysState"] if use_stock else \
+        (4 if enabled else lkas11["CF_Lkas_LdwsSysState"]),
     "CF_Lkas_SysWarning": lkas11["CF_Lkas_SysWarning"] if use_stock else hud_alert,
     "CF_Lkas_LdwsLHWarning": lkas11["CF_Lkas_LdwsLHWarning"] if keep_stock else 0,
     "CF_Lkas_LdwsRHWarning": lkas11["CF_Lkas_LdwsRHWarning"] if keep_stock else 0,

--- a/selfdrive/controls/lib/latcontrol.py
+++ b/selfdrive/controls/lib/latcontrol.py
@@ -82,6 +82,7 @@ class LatControl(object):
     self.rough_steers_rate_increment = 0.0
     self.prev_angle_steers = 0.0
     self.calculate_rate = True
+    self.sat_time = 0.0
 
     # variables for dashboarding
     self.context = zmq.Context()
@@ -277,7 +278,21 @@ class LatControl(object):
         PL.PP.d_poly[0], PL.PP.d_poly[1], PL.PP.d_poly[2], PL.PP.lane_width, PL.PP.lane_width_estimate, PL.PP.lane_width_certainty, v_ego, \
         self.pid.p, self.pid.i, self.pid.f, self.curvature_factor, VM.gsfc, VM.curvf, VM.sf, int(time.time() * 100) * 10000000))
 
-    self.sat_flag = self.pid.saturated
+    # If PID is saturated, set time which it was saturated
+    if self.pid.saturated and sat_time < 1.0:
+      sat_time = sec_since_boot()
+
+    # To save cycles, nest in sat_time check
+    if sat_time > 1.0:
+      # If its been saturated for 1.5 seconds then set flag
+      if (sec_since_boot() - sat_time) > 1.5:
+        self.sat_flag = True
+
+      # If it is no longer saturated, clear the sat flag and timer
+      if not self.pid.saturated:
+        sat_time = 0.0
+        self.sat_flag = False
+      
     self.prev_angle_rate = angle_rate
     self.prev_angle_steers = angle_steers
 

--- a/selfdrive/controls/lib/latcontrol.py
+++ b/selfdrive/controls/lib/latcontrol.py
@@ -278,20 +278,22 @@ class LatControl(object):
         PL.PP.d_poly[0], PL.PP.d_poly[1], PL.PP.d_poly[2], PL.PP.lane_width, PL.PP.lane_width_estimate, PL.PP.lane_width_certainty, v_ego, \
         self.pid.p, self.pid.i, self.pid.f, self.curvature_factor, VM.gsfc, VM.curvf, VM.sf, int(time.time() * 100) * 10000000))
 
+    # Reset sat_flat always, set it only if needed
+    self.sat_flag = False
+
     # If PID is saturated, set time which it was saturated
-    if self.pid.saturated and sat_time < 1.0:
-      sat_time = sec_since_boot()
+    if self.pid.saturated and self.sat_time < 0.5:
+      self.sat_time = sec_since_boot()
 
     # To save cycles, nest in sat_time check
-    if sat_time > 1.0:
+    if self.sat_time > 0.5:
       # If its been saturated for 1.5 seconds then set flag
-      if (sec_since_boot() - sat_time) > 1.5:
+      if (sec_since_boot() - self.sat_time) > 0.7:
         self.sat_flag = True
 
       # If it is no longer saturated, clear the sat flag and timer
       if not self.pid.saturated:
-        sat_time = 0.0
-        self.sat_flag = False
+        self.sat_time = 0.0
       
     self.prev_angle_rate = angle_rate
     self.prev_angle_steers = angle_steers


### PR DESCRIPTION
- Updated LKAS Dash Icon as voted in Discord
- Added 0.7 second delay to PID Sat Alarm *
- Indentation Cleanup
- Updated gitignore for 0.5.8 visiond and openpilot_tools

* PID Saturation Alarm is the one which screams when it fails to turn a corner.
Previously the instant that it saturated it would alarm.
I tested with different times, and at 0.7 seconds of constant saturation I am reliably starting to drift out of the lane.   Any more and I have already left the lane.
This may be fine to reduce even further, give feedback.